### PR TITLE
Update 02-Where_and_reusable_Expression_tree_visitor.md

### DIFF
--- a/tut/02-Where_and_reusable_Expression_tree_visitor.md
+++ b/tut/02-Where_and_reusable_Expression_tree_visitor.md
@@ -169,7 +169,7 @@ internal class QueryTranslator: ExpressionVisitor
         return c;
     }
 
-    protected override Expression VisitMemberAccess(MemberExpression m)
+    protected override Expression VisitMember(MemberExpression m)
     {
         if (m.Expression != null && m.Expression.NodeType == ExpressionType.Parameter)
         {


### PR DESCRIPTION
Seems like this one is changed over time, at least do not see such method to override